### PR TITLE
feat: add basic datagraph partitioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 .DS_Store
 **/.DS_Store
-/bin/out.plantuml
+
+bin/flower
+bin/out.plantuml
+bin/out_*
+
+data/example.sql
 
 .github
 .vscode
@@ -10,5 +15,3 @@ bazel-bin
 bazel-out
 bazel-testlogs
 bazel-flower
-
-data/*.sql

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,11 @@ run:
 test:
 	bazel test --test_output=errors //...
 
-docker:
+docker-build:
 	docker build . --tag flower:alpha
+
+docker-run:
+	docker run -it --rm -v $(CURDIR)/bin:/app/bin flower:alpha /bin/bash
 
 build:
 	go build -o ./bin/flower main.go

--- a/data/simple.sql
+++ b/data/simple.sql
@@ -1,0 +1,146 @@
+-- posts table
+CREATE TABLE public.posts (
+  id uuid NOT NULL,
+  name VARCHAR(34) NOT NULL,
+  description VARCHAR(514),
+  created_at timestamp without time zone NOT NULL,
+  user_id BIGINT NOT NULL,
+);
+
+ALTER TABLE ONLY public.posts
+  ADD CONSTRAINT posts_pkey PRIMARY KEY (id);
+
+-- users table
+CREATE TABLE public.users (
+  name VARCHAR(34) NOT NULL,
+  id BIGINT NOT NULL AUTO_INCREMENT,
+);
+
+ALTER TABLE ONLY public.users
+  ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+
+-- comments table
+CREATE TABLE public.comments (
+  user_id BIGINT NOT NULL,
+  content VARCHAR(514),
+  post_id BIGINT NOT NULL AUTO_INCREMENT,
+);
+
+-- autonomous1 table
+CREATE TABLE public.autonomous1 (
+  id BIGINT NOT NULL,
+  central_id BIGINT NOT NULL,
+);
+
+-- autonomous2 table
+CREATE TABLE public.autonomous2 (
+  id BIGINT NOT NULL,
+  central_id BIGINT NOT NULL,
+);
+
+-- autonomous3 table
+CREATE TABLE public.autonomous3 (
+  id BIGINT NOT NULL,
+  central_id BIGINT NOT NULL,
+);
+
+-- linked1 table
+CREATE TABLE public.linked1 (
+  id BIGINT NOT NULL,
+  central_id BIGINT NOT NULL,
+);
+
+-- linked2 table
+CREATE TABLE public.linked2 (
+  id BIGINT NOT NULL,
+  central_id BIGINT NOT NULL,
+);
+
+-- linked3 table
+CREATE TABLE public.linked3 (
+  id BIGINT NOT NULL,
+  central_id BIGINT NOT NULL,
+);
+
+-- linked4 table
+CREATE TABLE public.linked4 (
+  id BIGINT NOT NULL,
+  central_id BIGINT NOT NULL,
+);
+
+-- linked5 table
+CREATE TABLE public.linked5 (
+  id BIGINT NOT NULL,
+  central_id BIGINT NOT NULL,
+);
+
+-- linked6 table
+CREATE TABLE public.linked6 (
+  id BIGINT NOT NULL,
+  central_id BIGINT NOT NULL,
+);
+
+-- central link table
+CREATE TABLE public.centrallink (
+  id BIGINT NOT NULL,
+);
+
+ALTER TABLE ONLY public.linked1
+  ADD CONSTRAINT linked1_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY public.linked2
+  ADD CONSTRAINT linked2_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY public.linked3
+  ADD CONSTRAINT linked3_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY public.linked4
+  ADD CONSTRAINT linked4_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY public.linked5
+  ADD CONSTRAINT linked5_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY public.linked6
+  ADD CONSTRAINT linked6_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY public.linked1
+  ADD CONSTRAINT linked1_pkey PRIMARY KEY (id);
+
+ALTER TABLE public.linked1 ADD CONSTRAINT
+  FOREIGN KEY (central_id)
+  REFERENCES public.centrallink(id);
+
+ALTER TABLE public.linked2 ADD CONSTRAINT
+  FOREIGN KEY (central_id)
+  REFERENCES public.centrallink(id);
+
+ALTER TABLE public.linked3 ADD CONSTRAINT
+  FOREIGN KEY (central_id)
+  REFERENCES public.centrallink(id);
+
+ALTER TABLE public.linked4 ADD CONSTRAINT
+  FOREIGN KEY (central_id)
+  REFERENCES public.centrallink(id);
+
+ALTER TABLE public.linked5 ADD CONSTRAINT
+  FOREIGN KEY (central_id)
+  REFERENCES public.centrallink(id);
+
+ALTER TABLE public.linked6 ADD CONSTRAINT
+  FOREIGN KEY (central_id)
+  REFERENCES public.centrallink(id);
+
+ALTER TABLE ONLY public.comments
+  ADD CONSTRAINT comments_pkey PRIMARY KEY (user_id, post_id);
+
+ALTER TABLE public.comments ADD CONSTRAINT
+  FOREIGN KEY (post_id)
+  REFERENCES public.posts(id);
+
+ALTER TABLE public.comments ADD CONSTRAINT
+  FOREIGN KEY (user_id)
+  REFERENCES public.users(id);
+
+ALTER TABLE public.posts ADD CONSTRAINT
+  FOREIGN KEY (user_id)
+  REFERENCES public.users(id);

--- a/pkg/cmd/parse.go
+++ b/pkg/cmd/parse.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
+	"github.com/epsxy/flower/pkg/global"
 	"github.com/epsxy/flower/pkg/reader"
 	"github.com/spf13/cobra"
 )
@@ -17,13 +19,41 @@ var Parse = &cobra.Command{
 		SetGlobalFlags(cmd)
 		input, _ := cmd.Flags().GetString("input")
 		output, _ := cmd.Flags().GetString("output")
+		partition, _ := cmd.Flags().GetBool("partition")
+
+		logger := global.GetLogger()
 
 		dat, err := os.ReadFile(input)
 		if err != nil {
 			os.Exit(1)
 		}
 		tree := reader.Read(string(dat))
-		err = os.WriteFile(output, []byte(tree.Build()), 0644)
+
+		if !partition {
+			res := tree.Build()
+			err := os.WriteFile(output, []byte(res), 0644)
+			if err != nil {
+				logger.Error("unable to save file", "filename", output)
+			}
+		} else {
+			res := tree.BuildWithPartitions()
+			for i, r := range res {
+				var prefix, extension string
+				split := strings.SplitN(output, ".", 2)
+				if len(split) == 2 {
+					prefix = split[0]
+					extension = split[1]
+				} else {
+					prefix = output
+					extension = ".plantuml"
+				}
+				filename := fmt.Sprintf("%s_%d.%s", prefix, i, extension)
+				err := os.WriteFile(filename, []byte(r), 0644)
+				if err != nil {
+					logger.Error("unable to save file", "filename", filename)
+				}
+			}
+		}
 		if err != nil {
 			fmt.Println("unable to write file")
 			os.Exit(1)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -41,10 +41,11 @@ func Execute(version string) {
 	// setup version
 	root.Version = version
 	// add commands and flags
-	Parse.PersistentFlags().String("input", "", "SQL file to read")
-	Parse.PersistentFlags().String("output", "", "PlantUML file to write")
+	Parse.PersistentFlags().String("input", "", "Path to SQL file to read")
+	Parse.PersistentFlags().String("output", "", "Path to PlantUML file to write (including '.plantuml' extension)")
+	Parse.PersistentFlags().Bool("partition", false, "Split the disconnected data graph into connected data graph, one per file. Default=false")
 	root.AddCommand(Parse)
-	//Release.AddCommand(Major, Minor, Fix)
+
 	root.PersistentFlags().Var(&logLevel, "log-level", "Log level: 'debug', 'info', 'debug' or 'error'")
 	//root.PersistentFlags().Bool("dry-run", false, "enable dry-run mode")
 	//root.PersistentFlags().Bool("verbose", false, "enable verbose mode")

--- a/pkg/graph/BUILD.bazel
+++ b/pkg/graph/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "graph",
+    srcs = ["dfs.go"],
+    importpath = "github.com/epsxy/flower/pkg/graph",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/utils"],
+)

--- a/pkg/graph/dfs.go
+++ b/pkg/graph/dfs.go
@@ -1,0 +1,30 @@
+package graph
+
+import (
+	"sort"
+
+	"github.com/epsxy/flower/pkg/utils"
+)
+
+func Dfs_root(vertexes []string, graph map[string][]string, visited map[string]bool) [][]string {
+	var partitions [][]string = [][]string{}
+	for _, v := range vertexes {
+		if !utils.Array2DContains(partitions, v) {
+			c := _dfs_impl(v, graph, visited, []string{})
+			sort.Strings(c)
+			partitions = append(partitions, c)
+		}
+	}
+	return partitions
+}
+
+func _dfs_impl(vertex string, graph map[string][]string, visited map[string]bool, current []string) []string {
+	visited[vertex] = true
+	current = utils.AppendWithoutDuplicates(current, vertex)
+	for _, v := range graph[vertex] {
+		if !visited[v] {
+			current = _dfs_impl(v, graph, visited, current)
+		}
+	}
+	return current
+}

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -1,5 +1,10 @@
 package model
 
+import (
+	"sort"
+	"strings"
+)
+
 type Table struct {
 	Name         string            `yaml:"name,flow"`
 	Fields       []*Field          `yaml:"fields,flow"`
@@ -43,4 +48,20 @@ type Link struct {
 	SourceName      string `yaml:"sourceName,flow"`
 	DestinationName string `yaml:"destinationName,flow"`
 	IsNullable      bool   `yaml:"isNullable,flow"`
+}
+
+func (l *EntityLink) Id() string {
+	if l.Left != nil {
+		return GenLinkId(l.Left.DestinationName, l.Left.SourceName)
+	}
+	if l.Right != nil {
+		return GenLinkId(l.Right.DestinationName, l.Right.SourceName)
+	}
+	return ""
+}
+
+func GenLinkId(tableA, tableB string) string {
+	idArr := []string{tableA, tableB}
+	sort.Strings(idArr)
+	return strings.Join(idArr, "_")
 }

--- a/pkg/utils/BUILD.bazel
+++ b/pkg/utils/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "utils",
+    srcs = ["array.go"],
+    importpath = "github.com/epsxy/flower/pkg/utils",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/utils/array.go
+++ b/pkg/utils/array.go
@@ -1,0 +1,27 @@
+package utils
+
+func ArrayContains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}
+
+func Array2DContains(a [][]string, b string) bool {
+	for _, i := range a {
+		if ArrayContains(i, b) {
+			return true
+		}
+	}
+	return false
+}
+
+func AppendWithoutDuplicates(a []string, b string) []string {
+	if ArrayContains(a, b) {
+		return a
+	}
+	a = append(a, b)
+	return a
+}

--- a/pkg/writer/BUILD.bazel
+++ b/pkg/writer/BUILD.bazel
@@ -5,7 +5,11 @@ go_library(
     srcs = ["writer.go"],
     importpath = "github.com/epsxy/flower/pkg/writer",
     visibility = ["//visibility:public"],
-    deps = ["//pkg/model"],
+    deps = [
+        "//pkg/global",
+        "//pkg/graph",
+        "//pkg/model",
+    ],
 )
 
 go_test(
@@ -13,6 +17,7 @@ go_test(
     srcs = ["writer_test.go"],
     embed = [":writer"],
     deps = [
+        "//pkg/global",
         "//pkg/model",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/writer/writer_test.go
+++ b/pkg/writer/writer_test.go
@@ -1,8 +1,10 @@
 package writer
 
 import (
+	"log/slog"
 	"testing"
 
+	"github.com/epsxy/flower/pkg/global"
 	"github.com/epsxy/flower/pkg/model"
 	"github.com/stretchr/testify/require"
 )
@@ -217,6 +219,8 @@ const linkCommentsPosts = `public.comments }|--|| public.posts`
 const linkCommentsUsers = `public.comments }|--|| public.users`
 
 func Test_Build(t *testing.T) {
+	global.SetLogger(slog.LevelError)
+
 	res := input.Build()
 
 	require.Contains(t, res, postsTable)


### PR DESCRIPTION
# Motivation

This PR support basic datagraph partitioning. It splits the big unconnected datagraph into several children connected datagraphs, one per file.

## Usage

```
> flower parse --input schema.sql --output out.plantuml  --partition
```